### PR TITLE
fix source-paths for db profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,8 @@
                                                         {:src "js/main.js"}
                                                         {:body "goog.require('dacom.client')"}
                                                         {:body "goog.require('dacom.repl')"}]}}}
-             :db {:main dacom.db}
+             :db {:main dacom.db
+                  :source-paths ["utils/src"]}
              :prod {:main dacom.server
                     :target-path "dist/server/"
                     :resource {:resource-paths ["web-resources/pages"]


### PR DESCRIPTION
Without this patch I've got "Can't find 'runes24.db' as .class or .clj for lein run: please check the spelling.
Exception in thread "main" java.io.FileNotFoundException: Could not locate runes24/db__init.class or runes24/db.clj on classpath: ..." when `lein install-db`
